### PR TITLE
Tagger

### DIFF
--- a/DStutorial/utils/create-space/src/README
+++ b/DStutorial/utils/create-space/src/README
@@ -1,3 +1,0 @@
-This directory contains the POS tagger by Matthew Honnibal. Check out
-https://honnibal.wordpress.com/2013/09/11/a-good-part-of-speechpos-tagger-in-about-200-lines-of-python/
-for more information.

--- a/DStutorial/utils/create-space/src/README
+++ b/DStutorial/utils/create-space/src/README
@@ -1,0 +1,3 @@
+This directory contains the POS tagger by Matthew Honnibal. Check out
+https://honnibal.wordpress.com/2013/09/11/a-good-part-of-speechpos-tagger-in-about-200-lines-of-python/
+for more information.


### PR DESCRIPTION
Removing src directory. Assuming people will install tagger from https://github.com/sloria/textblob-aptagger.